### PR TITLE
disable builds of nightly python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "nightly"
 install:
   - pip install tox-travis
   - pip install coveralls


### PR DESCRIPTION
The build of python might fail resulting in a failed hbmqtt build.  This results in a false impression of an unstable build on hbmqtt's side.